### PR TITLE
Refactor labor market cycle and normalize economic constants

### DIFF
--- a/src/config/ConfigEconomica.py
+++ b/src/config/ConfigEconomica.py
@@ -108,13 +108,13 @@ class ConfigEconomica:
     PREFERENCIA_VARIEDAD = 0.15  # Tendencia a diversificar compras
     
     # Distribución de ingresos heterogénea
-    DISTRIBUCION_INGRESOS = 'lognormal'  # 'lognormal' o 'uniforme'
+    DISTRIBUCION_INGRESOS = 0  # 0='lognormal', 1='uniforme'
     INGRESO_LOGNORMAL_MU = 8.5  # Media del log (corresponde aprox a $5000)
     INGRESO_LOGNORMAL_SIGMA = 0.8  # Desviación estándar del log
     INGRESO_MIN_GARANTIZADO = 1500  # Ingreso mínimo garantizado
     
     # Tipos de preferencias de consumo
-    TIPO_PREFERENCIAS = 'cobb_douglas'  # 'cobb_douglas' o 'ces'
+    TIPO_PREFERENCIAS = 0  # 0='cobb_douglas', 1='ces'
     CES_ELASTICITY_SUBSTITUTION = 1.5  # Para preferencias CES
     
     # Restricción intertemporal
@@ -167,3 +167,27 @@ class ConfigEconomica:
     }
     IMPUESTO_CARBONO = 5  # Unidad monetaria por unidad de emisión
     LIMITE_EXTRACCION_RECURSOS = 0.1  # 10% de recursos restantes como umbral crítico
+
+    @staticmethod
+    def obtener_distribucion_ingresos(valor):
+        """Normaliza la configuración de distribución de ingresos"""
+        if isinstance(valor, str):
+            return valor
+
+        mapping = {
+            0: 'lognormal',
+            1: 'uniforme'
+        }
+        return mapping.get(valor, 'lognormal')
+
+    @staticmethod
+    def obtener_tipo_preferencias(valor):
+        """Devuelve el identificador de preferencias de consumo"""
+        if isinstance(valor, str):
+            return valor
+
+        mapping = {
+            0: 'cobb_douglas',
+            1: 'ces'
+        }
+        return mapping.get(valor, 'cobb_douglas')

--- a/src/models/Consumidor.py
+++ b/src/models/Consumidor.py
@@ -63,7 +63,8 @@ class Consumidor(Persona):
         self.factor_paciencia = random.uniform(paciencia_min, paciencia_max)
         
         # Tipo de preferencias (Cobb-Douglas o CES)
-        self.tipo_preferencias = self.config_hetero.get('tipo_preferencias', ConfigEconomica.TIPO_PREFERENCIAS)
+        tipo_pref_config = self.config_hetero.get('tipo_preferencias', ConfigEconomica.TIPO_PREFERENCIAS)
+        self.tipo_preferencias = ConfigEconomica.obtener_tipo_preferencias(tipo_pref_config)
         self.ces_elasticity = self.config_hetero.get('ces_elasticity_substitution', ConfigEconomica.CES_ELASTICITY_SUBSTITUTION)
         
         # Coeficientes de preferencias para Cobb-Douglas
@@ -102,7 +103,8 @@ class Consumidor(Persona):
 
     def _generar_dinero_inicial(self):
         """Genera dinero inicial usando distribución lognormal o uniforme"""
-        distribucion = self.config_hetero.get('distribucion_ingresos', ConfigEconomica.DISTRIBUCION_INGRESOS)
+        distribucion_config = self.config_hetero.get('distribucion_ingresos', ConfigEconomica.DISTRIBUCION_INGRESOS)
+        distribucion = ConfigEconomica.obtener_distribucion_ingresos(distribucion_config)
         
         if distribucion == 'lognormal':
             mu = self.config_hetero.get('ingreso_lognormal_mu', ConfigEconomica.INGRESO_LOGNORMAL_MU)
@@ -122,7 +124,8 @@ class Consumidor(Persona):
     
     def _generar_ingreso_inicial(self):
         """Genera ingreso inicial usando distribución lognormal o uniforme"""
-        distribucion = self.config_hetero.get('distribucion_ingresos', ConfigEconomica.DISTRIBUCION_INGRESOS)
+        distribucion_config = self.config_hetero.get('distribucion_ingresos', ConfigEconomica.DISTRIBUCION_INGRESOS)
+        distribucion = ConfigEconomica.obtener_distribucion_ingresos(distribucion_config)
         
         if distribucion == 'lognormal':
             mu = self.config_hetero.get('ingreso_lognormal_mu', ConfigEconomica.INGRESO_LOGNORMAL_MU)

--- a/src/systems/MercadoLaboral.py
+++ b/src/systems/MercadoLaboral.py
@@ -132,11 +132,11 @@ class MercadoLaboral:
                     f"✅ {contrataciones_exitosas} contrataciones de emergencia realizadas")
 
     def ciclo_mercado_laboral(self):
-        """Ciclo principal del mercado laboral con contrataciones y despidos dinámicos"""
+        """Ejecuta el ciclo completo del mercado laboral"""
         # 1. Facilitar contrataciones si hay alto desempleo
         self.facilitar_contrataciones_masivas()
 
-        # 2. Gestionar despidos por crisis económica
+        # 2. Gestionar despidos o contrataciones según el ciclo económico
         if hasattr(self.mercado, 'fase_ciclo_economico'):
             if self.mercado.fase_ciclo_economico in ['recesion', 'depresion']:
                 self._gestionar_despidos_por_crisis()
@@ -145,6 +145,24 @@ class MercadoLaboral:
 
         # 3. Movilidad laboral básica
         self._procesar_movilidad_laboral()
+
+        # 4. Crear empresas emergentes si es necesario
+        self.crear_empresas_emergentes()
+
+        # 5. Procesar aportes sindicales
+        self._procesar_aportes_sindicales()
+
+        # 6. Reasignar trabajadores con perfiles incompatibles
+        self.reasignar_trabajadores_incompatibles()
+
+    def _procesar_aportes_sindicales(self):
+        """Descuenta los aportes sindicales de los trabajadores afiliados"""
+        for sindicato in self.sindicatos:
+            for miembro in sindicato.miembros:
+                if miembro.empleado and hasattr(miembro, 'ingreso_mensual'):
+                    aporte = sindicato.calcular_aporte(miembro.ingreso_mensual)
+                    if getattr(miembro, 'dinero', 0) >= aporte:
+                        miembro.dinero -= aporte
 
     def _gestionar_despidos_por_crisis(self):
         """Gestiona despidos durante crisis económica"""
@@ -179,7 +197,10 @@ class MercadoLaboral:
 
     def _procesar_movilidad_laboral(self):
         """Procesa movilidad laboral básica entre sectores"""
-        empleados = [c for c in self.mercado.getConsumidores() if c.empleado]
+        empleados = [
+            c for c in self.mercado.getConsumidores()
+            if c.empleado and getattr(c, 'empleador', None)
+        ]
 
         # 5% de empleados pueden cambiar de trabajo cada ciclo
         empleados_moviles = random.sample(
@@ -189,21 +210,37 @@ class MercadoLaboral:
             if random.random() < 0.1:  # 10% probabilidad de cambio
                 # Buscar mejor oportunidad
                 empresas_alternativas = [e for e in self.mercado.getEmpresas()
-                                         if e != empleado.empleador and hasattr(e, 'dinero')
-                                         and e.dinero > 50000]
+                                         if e != getattr(empleado, 'empleador', None)
+                                         and hasattr(e, 'dinero') and e.dinero > 50000]
 
                 if empresas_alternativas:
                     nueva_empresa = random.choice(empresas_alternativas)
                     salario_actual = empleado.ingreso_mensual
+                    empresa_actual = getattr(empleado, 'empleador', None)
+
+                    if not empresa_actual or not hasattr(empresa_actual, 'despedir'):
+                        continue
 
                     # Intentar obtener mejor salario
                     nuevo_salario = salario_actual * \
                         random.uniform(1.05, 1.15)  # 5-15% aumento
 
                     if nueva_empresa.dinero > nuevo_salario * 12:  # Puede pagar el salario anual
-                        empleado.empleador.despedir(empleado)
+                        empresa_actual.despedir(empleado)
+                        ingreso_original = empleado.ingreso_mensual
                         empleado.ingreso_mensual = nuevo_salario
-                        nueva_empresa.contratar(empleado)
+                        if nueva_empresa.contratar(empleado):
+                            empleado.empleador = nueva_empresa
+                            empleado.empleado = True
+                        else:
+                            # Revertir si la contratación falla
+                            empleado.ingreso_mensual = ingreso_original
+                            if hasattr(empresa_actual, 'contratar'):
+                                empresa_actual.contratar(empleado)
+                                empleado.empleador = empresa_actual
+                            else:
+                                empleado.empleado = False
+                                empleado.empleador = None
 
     def crear_empresas_emergentes(self):
         """Crea nuevas empresas pequeñas para absorber desempleo"""
@@ -298,25 +335,6 @@ class MercadoLaboral:
                         candidato.empleado = True
                         if candidato in desempleados:
                             desempleados.remove(candidato)
-
-    def ciclo_mercado_laboral(self):
-        """Ejecuta el ciclo completo del mercado laboral"""
-        # 1. Facilitar contrataciones masivas si hay alto desempleo
-        self.facilitar_contrataciones_masivas()
-
-        # 2. Crear empresas emergentes si es necesario
-        self.crear_empresas_emergentes()
-
-        # 3. Procesar aportes sindicales
-        for sindicato in self.sindicatos:
-            for miembro in sindicato.miembros:
-                if miembro.empleado and hasattr(miembro, 'ingreso_mensual'):
-                    aporte = sindicato.calcular_aporte(miembro.ingreso_mensual)
-                    if miembro.dinero >= aporte:
-                        miembro.dinero -= aporte
-
-        # 4. Reasignar trabajadores con perfiles incompatibles
-        self.reasignar_trabajadores_incompatibles()
 
     def reasignar_trabajadores_incompatibles(self):
         """Reasigna trabajadores que no están en su sector óptimo"""


### PR DESCRIPTION
## Summary
- merge the duplicate labor market cycle into a single routine that also handles union dues and mobility safely
- normalize configurable distribution and preference constants to numeric codes with helper accessors
- update consumer initialization to resolve distribution and preference codes through the new helpers

## Testing
- pytest tests/unit/test_sistemas_reales.py::TestConfigEconomicaBasico::test_buscar_otras_constantes
- pytest tests/integration/test_simulacion_completa.py::TestIntegracionCompleta::test_banco_central_avanzado_funcionamiento

------
https://chatgpt.com/codex/tasks/task_e_68f37ac518088327b4d77953e779c6d1